### PR TITLE
drivebar refresh when hardware changes

### DIFF
--- a/drivebar/script.js
+++ b/drivebar/script.js
@@ -1,4 +1,4 @@
-﻿var Addon_Id = "drivebar";
+var Addon_Id = "drivebar";
 var Default = "ToolBar1Right";
 
 if (window.Addon == 1) {
@@ -30,8 +30,8 @@ if (window.Addon == 1) {
 		}
 
 	};
-
-	AddEvent("DeviceChanged", function (Ctrl)
+	
+	function updateDeviceList(Ctrl)
 	{
 		var icon = [53, 7, 8, 9, 11, 12];
 		var image = te.WICBitmap();
@@ -70,7 +70,10 @@ if (window.Addon == 1) {
 			}
 		}
 		document.getElementById("drivebar").innerHTML = arDrive.join("");
-	});
+	}
+	
+	AddEvent("AppMessage", updateDeviceList);
+	AddEvent("DeviceChanged", updateDeviceList);
 
 	SetAddon(Addon_Id, Default, '<span id="drivebar"></span>');
 }


### PR DESCRIPTION
drivebar addon did not refresh when a device was connected or disconnected.
Moved the code of inline function from event "DeviceChanged" to updateDeviceList(). 
This function is now additionally called on event "AppMessage".
As a result the drivebar automatically refreshes when a device is connected or disconnected.