### PR TITLE
Improve description for tab groups

### DIFF
--- a/tabgroups/config.xml
+++ b/tabgroups/config.xml
@@ -11,7 +11,7 @@
   </General>
   <en>
     <Name>Tab groups</Name>
-    <Description>Tab groups</Description>
+    <Description>Groups all panes containing several tabs into independent workspaces displayed as a tab bar</Description>
   </en>
   <ja>
     <Name>タブ グループ</Name>


### PR DESCRIPTION
Improve addon description
Groups all panes containing several tabs into independent workspaces displayed as a tab bar