### PR TITLE
Fix error when tabplus align is not default

### DIFF
--- a/tabplus/script.js
+++ b/tabplus/script.js
@@ -408,7 +408,10 @@ if (window.Addon == 1) {
 					if (Addons.TabPlus.opt.Align > 1) {
 						const o = document.getElementById("Panel_" + id);
 						if (o) {
-							document.getElementById("tabplus_" + id).style.height = o.clientHeight + "px";
+							const p = document.getElementById("tabplus_" + id);
+							if (p) {
+								p.style.height = o.clientHeight + "px";
+							}
 						}
 					}
 				}


### PR DESCRIPTION
タブプラスの「配置」がデフォルト（「上」）でない時に、以下のようなエラーが発生する不具合に対応しました。

![tabplus_error](https://user-images.githubusercontent.com/5264444/100720027-c3874a80-3400-11eb-8442-8fa2ddbe26a8.png)

`document.getElementById("tabplus_" + id)` が取得できなかった場合は何もしないようにする、という対応です。
……が、パネルがあるのにタブは無い、という状態がそもそもありえないはずなので、根本的な解決にはなっていないかもしれません。