### PR TITLE
Add option for title bar show full path

### DIFF
--- a/titlebar/config.xml
+++ b/titlebar/config.xml
@@ -4,6 +4,7 @@
     <Version>1.09</Version>
     <MinVersion>2021.3.27</MinVersion>
     <pubDate>Tue, 17 Aug 2021 00:00:00 GMT</pubDate>
+    <Options>Common:0:0</Options>
     <Level>2</Level>
     <Creator>Gaku</Creator>
     <URL>https://tablacus.github.io/TablacusExplorerAddons/</URL>

--- a/titlebar/options.html
+++ b/titlebar/options.html
@@ -1,0 +1,2 @@
+<label>Show full path</label><br>
+<label><input type="checkbox" name="ShowFullPath">Enable</label>

--- a/titlebar/script.js
+++ b/titlebar/script.js
@@ -1,5 +1,21 @@
 if (window.Addon == 1) {
+	const Addon_Id = "titlebar";
+	const item = GetAddonElement(Addon_Id);
+	const show_fullpath = GetNum(item.getAttribute("ShowFullPath"));
+
 	AddEvent("ChangeView1", async function (Ctrl) {
-		document.title = await Ctrl.Title + ' - ' + TITLE;
+		if (show_fullpath) {
+			const pid = await Ctrl.FolderItem;
+			let fullpath;
+			if (pid && (fullpath = await pid.Path) && fullpath.length > 0) {
+				document.title = fullpath + ' - ' + TITLE;
+			} else {
+				document.title = await Ctrl.Title + ' - ' + TITLE;
+			}
+		} else {
+			document.title = await Ctrl.Title + ' - ' + TITLE;
+		}
 	});
+} else {
+	SetTabContents(0, "General", await ReadTextFile("addons\\" + Addon_Id + "\\options.html"));
 }


### PR DESCRIPTION
# Summary

This PR adds an option to display the full path of the currently active tab’s directory in the Tablacus Explorer window title.

---

## Background

QuickSwitch synchronizes the path of any application’s Open/Save dialog with a file manager, eliminating repetitive manual navigation. Existing QuickSwitch integrations include:

- Windows Explorer
- TotalCommander
- Directory Opus
- XYplorer

To extend QuickSwitch support to Tablacus Explorer, we need a reliable way to retrieve the current folder path from its UI.

---

## Changes

- Introduce a new setting in Tablacus Explorer that, when enabled, appends the full path of the frontmost tab’s directory to the program title bar.
- Ensure the path is updated dynamically as the user switches tabs.
- Provide the necessary export of this title‐bar text for external tools (e.g., QuickSwitch) to consume.

---

## Motivation

By embedding the active tab’s full directory path in the window title, QuickSwitch can read and synchronize that path into any application’s file dialog. This streamlines workflows, removes redundant clicks, and prepares the foundation for Tablacus Explorer support in QuickSwitch.

---

## Next Steps

- Update QuickSwitch to detect and parse the Tablacus Explorer window title.
- Add Tablacus Explorer to QuickSwitch’s list of supported file managers.
- Write tests and validation to ensure seamless path synchronization across environments.