### PR TITLE
Added "Remove OneDrive Status Column" add-on

### DIFF
--- a/removeonedrivestatuscolumn/config.xml
+++ b/removeonedrivestatuscolumn/config.xml
@@ -1,0 +1,20 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<TablacusExplorer>
+  <General>
+    <Version>1.00</Version>
+    <MinVersion>2025.11.13</MinVersion>
+    <pubDate>Friday, 19 Dec 2025 00:00:00 GMT</pubDate>
+    <Level>2</Level>
+    <Creator>LoganAC34</Creator>
+    <URL>https://tablacus.github.io/TablacusExplorerAddons/</URL>
+    <License>MIT License</License>
+  </General>
+  <en>
+    <Name>Remove OneDrive Status Column</Name>
+    <Description>Remove OneDrive's "Status" column from all views automatically.</Description>
+  </en>
+  <ja>
+    <Name>OneDrive ステータス列を削除する</Name>
+    <Description>OneDrive の「ステータス」列をすべてのビューから自動的に削除します。</Description>
+  </ja>
+</TablacusExplorer>

--- a/removeonedrivestatuscolumn/script.js
+++ b/removeonedrivestatuscolumn/script.js
@@ -1,0 +1,18 @@
+﻿if (window.Addon == 1) {
+	Addons.RemoveStatusColumn = {
+		Status: '"' + await api.PSGetDisplayName("System.StorageProviderUIStatus") + '"',
+
+		Exec: async function (Ctrl) {
+			const s = await Ctrl.Columns;
+			if (s.indexOf(Addons.RemoveStatusColumn.Status) >= 0) {
+				var re = new RegExp(Addons.RemoveStatusColumn.Status + " \\d+", "g");
+				Ctrl.Columns = s.replace(re, "");
+			}
+		}
+	};
+
+	if (Addons.RemoveStatusColumn.Status != '""') {
+		AddEvent("NavigateComplete", Addons.RemoveStatusColumn.Exec);
+		AddEvent("ColumnsChanged", Addons.RemoveStatusColumn.Exec);
+	}
+}


### PR DESCRIPTION
I created this because I was tired of the OneDrive "Status" column reappearing when I would manually remove it. This removes that column in all folders automatically.

OneDriveの「状態」列を手動で削除しても再び表示されてしまうのにうんざりしていたので、このツールを作成しました。このツールを使うと、すべてのフォルダからその列が自動的に削除されます。